### PR TITLE
Move files around such that dependency on Labs' file layout isn't needed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,9 @@
 
 getAllUsersStorage.py
-
 *.pyc
 
 SPIArticleAnalyzer/.DS_Store
 
 .DS_Store
+
+.idea/*

--- a/SPIArticleAnalyzer/app.py
+++ b/SPIArticleAnalyzer/app.py
@@ -5,7 +5,6 @@ from builtins import input
 
 import sys
 import os
-sys.path.append(os.path.expanduser("/SPIArticleAnalyzer"))
 from getAllUsers import *
 
 # Generate a random secret application key

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 flask
 flask-mwoauth>=0.1.14
 werkzeug>=0.9
+geoip2


### PR DESCRIPTION
This needs a symbolic link on labs (already in place) from  ~/www/python/src/  to  ./SPIArticleAnalyzer